### PR TITLE
Use dialcontext instead of deprecated dial and enable tls

### DIFF
--- a/client/xmlrpc_client.go
+++ b/client/xmlrpc_client.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"crypto/tls"
 	"net"
 	"net/http"
 	"time"
@@ -41,8 +40,7 @@ func timeoutDialer(connectTimeout, requestTimeout time.Duration) func(ctx contex
 
 func getClientWithTimeout(url string, connectTimeout, requestTimeout int) (*xmlrpc.Client, error) {
 	transport := http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		DialContext:     timeoutDialer(time.Duration(connectTimeout)*time.Second, time.Duration(requestTimeout)*time.Second),
+		DialContext: timeoutDialer(time.Duration(connectTimeout)*time.Second, time.Duration(requestTimeout)*time.Second),
 	}
 	return xmlrpc.NewClient(url, &transport)
 }

--- a/client/xmlrpc_client.go
+++ b/client/xmlrpc_client.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"context"
+	"crypto/tls"
 	"net"
 	"net/http"
 	"time"
@@ -26,8 +28,8 @@ func (c *Client) ExecuteCall(endpoint string, call string, args []interface{}) (
 	return response, err
 }
 
-func timeoutDialer(connectTimeout, requestTimeout time.Duration) func(net, addr string) (c net.Conn, err error) {
-	return func(netw, addr string) (net.Conn, error) {
+func timeoutDialer(connectTimeout, requestTimeout time.Duration) func(ctx context.Context, net, addr string) (c net.Conn, err error) {
+	return func(ctx context.Context, netw, addr string) (net.Conn, error) {
 		conn, err := net.DialTimeout(netw, addr, connectTimeout)
 		if err != nil {
 			return nil, err
@@ -39,7 +41,8 @@ func timeoutDialer(connectTimeout, requestTimeout time.Duration) func(net, addr 
 
 func getClientWithTimeout(url string, connectTimeout, requestTimeout int) (*xmlrpc.Client, error) {
 	transport := http.Transport{
-		Dial: timeoutDialer(time.Duration(connectTimeout)*time.Second, time.Duration(requestTimeout)*time.Second),
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		DialContext:     timeoutDialer(time.Duration(connectTimeout)*time.Second, time.Duration(requestTimeout)*time.Second),
 	}
 	return xmlrpc.NewClient(url, &transport)
 }

--- a/release/hub.conf
+++ b/release/hub.conf
@@ -1,3 +1,3 @@
-HUB_API_URL=http://localhost/rpc/api
+HUB_API_URL=https://localhost/rpc/api
 HUB_CONNECT_TIMEOUT=10
 HUB_REQUEST_TIMEOUT=10


### PR DESCRIPTION
This PR is doing 2 things.

1. Using `DialContext` instead of deprecated `Dial` 

2. Enable the TLS( for now it uses `InsecureSkipVerify` is true but in our case, maybe it's not bad because what this flag does is that client(our hub xmlrpc client) doesn't verify the server's chain and hostname, which should be fine). What we are still getting though is that our communication is now all encrypted. We can, of course, add certificate information if we are not comfortable with this situation.
 